### PR TITLE
Potential fix for code scanning alert no. 14: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "mime-types": "^3.0.1",
     "multer": "^2.0.2",
     "path-to-regexp": "^8.2.0",
-    "pdfkit": "^0.17.1"
+    "pdfkit": "^0.17.1",
+    "@fastify/rate-limit": "^10.3.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+const rateLimit = require('@fastify/rate-limit');
 const fastify = require('fastify')({ logger: true });
 const path = require('path');
 const fs = require('fs').promises;
@@ -8,6 +9,12 @@ const util = require('util');
 const stream = require('stream');
 const pipeline = util.promisify(stream.pipeline);
 const { setTimeout } = require('timers/promises');
+
+// Register rate limiter
+fastify.register(rateLimit, {
+  max: 100, // Limit each IP to 100 requests per 15 minutes
+  timeWindow: '15 minutes'
+});
 
 // Static files
 fastify.register(require('@fastify/static'), {
@@ -297,7 +304,7 @@ fastify.post(`${config.adminPath}/delete-file`, async (req, reply) => {
 });
 
 // Upload de fichier (déjà présent, mais sécurisé)
-fastify.post(`${config.adminPath}/upload-file`, async (req, reply) => {
+fastify.post(`${config.adminPath}/upload-file`, { config: { rateLimit: { max: 10, timeWindow: '1 minute' } } }, async (req, reply) => {
   fastify.log.info('Début upload');
   const parts = req.parts();
   let currentFolder = '';


### PR DESCRIPTION
Potential fix for [https://github.com/xxloubexx/Public-Drive/security/code-scanning/14](https://github.com/xxloubexx/Public-Drive/security/code-scanning/14)

To fix the issue, we need to add rate-limiting middleware to the application. This can be achieved by using the `@fastify/rate-limit` plugin, which is specifically designed for the Fastify framework. We will configure the rate limiter to limit the maximum number of requests within a specific time window. This will protect the file upload route from abuse.

The fix involves:
1. Installing the `@fastify/rate-limit` package.
2. Registering the rate-limiting plugin with appropriate configuration.
3. Applying the rate limiter to the specific route (`/upload-file`) or globally as needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
